### PR TITLE
Lift errors into types

### DIFF
--- a/src/main/scala/com/kinja/config/BootupErrors.scala
+++ b/src/main/scala/com/kinja/config/BootupErrors.scala
@@ -4,7 +4,7 @@ package com.kinja.config
  * A Bootup Errors accumulator. It accumulates errors when applied (<*>).
  * It is also a monad (but does not accumulate errors in that case).
  */
-final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[String], A]) extends AnyVal {
+final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[ConfigError], A]) extends AnyVal {
   def map[B](f : A ⇒ B) : BootupErrors[B] = BootupErrors(this.run.right.map(f))
 
   /** Sequentially apply another BootupErrors to this one, accumulating any errors therein. */
@@ -22,13 +22,13 @@ final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[String]
   /** Bind on another BootupErrors. Unlike `<*>` this does not accumulate errors. */
   def flatMap[B](f : A ⇒ BootupErrors[B]) : BootupErrors[B] = BootupErrors(this.run.right.flatMap(f(_).run))
 
-  def fold[B](err : Seq[String] ⇒ B, succ : A ⇒ B) : B = run.fold(err, succ)
-  def getOrElse(e : Seq[String] ⇒ A) : A = this.fold(e, a ⇒ a)
+  def fold[B](err : Seq[ConfigError] ⇒ B, succ : A ⇒ B) : B = run.fold(err, succ)
+  def getOrElse(e : Seq[ConfigError] ⇒ A) : A = this.fold(e, a ⇒ a)
 
   /**
    * Return all accumulated errors, if any
    */
-  def errors : Seq[String] = run.fold(a ⇒ a, _ ⇒ Nil)
+  def errors : Seq[ConfigError] = run.fold(a ⇒ a, _ ⇒ Nil)
 
   // TODO this should return None when the value is missing, Some when successful,
   // and a failed BootupErrors in all other situations.
@@ -42,5 +42,5 @@ final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[String]
 
 object BootupErrors {
   def apply[A](a : A) : BootupErrors[A] = BootupErrors(Right(a))
-  def failed[A](err : String) : BootupErrors[A] = BootupErrors(Left(err :: Nil))
+  def failed[A](err : ConfigError) : BootupErrors[A] = BootupErrors(Left(err :: Nil))
 }

--- a/src/main/scala/com/kinja/config/BootupErrorsException.scala
+++ b/src/main/scala/com/kinja/config/BootupErrorsException.scala
@@ -2,6 +2,6 @@ package com.kinja.config
 
 import scala.util.control.NoStackTrace
 
-class BootupConfigurationException(errors : Seq[String])
+class BootupConfigurationException(errors : Seq[ConfigError])
   extends RuntimeException("The following Bootup configuration errors were found: \n\t" + errors.mkString("\n\t"))
   with NoStackTrace

--- a/src/main/scala/com/kinja/config/ConfigError.scala
+++ b/src/main/scala/com/kinja/config/ConfigError.scala
@@ -1,0 +1,25 @@
+package com.kinja.config
+
+/**
+ * The types of errors that a BootupErrors can catch
+ */
+sealed trait ConfigError {
+  // The name of the configuration where the error was found
+  val configName : String
+
+  // Name of the value that was being accessed when the error was encountered
+  val valueName : String
+}
+
+object ConfigError {
+  // The value is simply missing from the configuration
+  final case class MissingValue(configName : String, valueName : String) extends ConfigError {
+    override def toString =
+      s"Could not find key `$valueName` in configuration `$configName`."
+  }
+  // The type expected did not match the actual type of the value
+  final case class WrongType(configName : String, valueName : String, expectedType : String) extends ConfigError {
+    override def toString =
+      s"Incorrect type for `$valueName` in configuration `$configName`. Expected $expectedType"
+  }
+}

--- a/src/main/scala/com/kinja/config/LiftedTypesafeConfig.scala
+++ b/src/main/scala/com/kinja/config/LiftedTypesafeConfig.scala
@@ -16,9 +16,9 @@ final case class LiftedTypesafeConfig private[LiftedTypesafeConfig] (configAndNa
     BootupErrors(f(name))
   } catch {
     case _ : ConfigException.WrongType ⇒
-      BootupErrors.failed(s"Incorrect type for `$name`. Expected ${ev.toString}.")
+      BootupErrors.failed(ConfigError.WrongType(configAndName._2, name, ev.toString))
     case _ : ConfigException.Missing ⇒
-      BootupErrors.failed(s"Could not find key `$name` in configuration `${configAndName._2}`.")
+      BootupErrors.failed(ConfigError.MissingValue(configAndName._2, name))
   }
 
   /** The underlying TypesafeConfig. */


### PR DESCRIPTION
@ChrisNeveu This PR lifts errors into types (from plain strings). 

However, remaking `optional` is not as easy as we first thought. `BootupErrors` is an `Either (Seq ConfigError) a`, which means that for any value `a`, we have `n` errors, some might be type errors, others might be missing value errors. This means there is no obvious function `optional :: BootupErrors a -> BootupErrors (Option a)`.

I think we are missing an underlying type `U a` of the shape `Either ConfigError a`; some sort of "get single value or error" type that can then be folded into a `BootupErrors`. This underlying type would contain an obvious function `optional :: U a -> U (Option a)`. 
