### PR TITLE
Add support for classes to @safeConfig.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,7 +36,7 @@ object Build extends Build {
     file("."),
     settings = Defaults.defaultSettings ++ scalariformSettings ++ wartremoverSettings ++ Seq(
       organization := "com.kinja",
-      version      := "1.0.1-SNAPSHOT",
+      version      := "1.1.0",
       scalaVersion := "2.11.6",
       pomExtra := pomStuff,
       scalacOptions ++= Seq(

--- a/src/test/scala/com/kinja/config/DependencyInjection.scala
+++ b/src/test/scala/com/kinja/config/DependencyInjection.scala
@@ -1,0 +1,7 @@
+package com.kinja.config
+
+import com.typesafe.config._
+
+abstract class DependencyInjection {
+  lazy val injectedConfig = ConfigFactory.load()
+}

--- a/src/test/scala/com/kinja/config/ProtectedMember.scala
+++ b/src/test/scala/com/kinja/config/ProtectedMember.scala
@@ -1,0 +1,7 @@
+package com.kinja.config
+
+import com.typesafe.config._
+
+abstract class ProtectedMember {
+  protected val someString : String = "bool"
+}

--- a/src/test/scala/com/kinja/config/TestConfigs.scala
+++ b/src/test/scala/com/kinja/config/TestConfigs.scala
@@ -120,3 +120,36 @@ object EmptyConfig {
 }
 
 final case class SomethingConfig(foo : Int, bar : String)
+
+@safeConfig("injectedConfig")
+class DepInjTest1() extends DependencyInjection {
+  val getBoolean1 = getBoolean("bool")
+}
+
+@safeConfig("rawConfig")
+class DepInjTest2() extends DependencyInjection {
+  private val rawConfig = injectedConfig
+  val getBoolean1 = getBoolean("bool")
+}
+
+@safeConfig("rawConfig")
+class DepInjTest3() extends DependencyInjection {
+  private val rawConfig : com.typesafe.config.Config = injectedConfig
+  val getBoolean1 = getBoolean("bool")
+}
+
+@safeConfig(testConf)
+object ProtectedMemberTest extends ProtectedMember {
+  val getBoolean1 = getBoolean(someString)
+}
+
+@safeConfig(testConf)
+class ClassArgTest1(private val someString : String) {
+  val getBoolean1 = getBoolean(someString)
+}
+
+@safeConfig("rawConfig")
+class ClassArgTest2(private val rawConfig : Config) {
+
+  val secret = getString("string")
+}

--- a/src/test/scala/com/kinja/config/safeConfigTest.scala
+++ b/src/test/scala/com/kinja/config/safeConfigTest.scala
@@ -114,4 +114,24 @@ class safeConfigTest extends FlatSpec with Matchers {
     }
     errorMessage should be("The following Bootup configuration errors were found: \n\tIncorrect type for `string` in configuration `root`. Expected Int.\n\tIncorrect type for `object-list` in configuration `root`. Expected Long.")
   }
+
+  it should "handle classes" in {
+    val concreteConf1 = new DepInjTest1
+    val concreteConf2 = new DepInjTest2
+    val concreteConf3 = new DepInjTest3
+    concreteConf1.getBoolean1 should be(true)
+    concreteConf2.getBoolean1 should be(true)
+    concreteConf3.getBoolean1 should be(true)
+  }
+
+  it should "handle classes with arguments" in {
+    val concreteConf1 = new ClassArgTest1("bool")
+    val concreteConf2 = new ClassArgTest2(testConf)
+    concreteConf1.getBoolean1 should be(true)
+    concreteConf2.secret should be("This is a string.")
+  }
+
+  it should "handle objects with protected mixins" in {
+    ProtectedMemberTest.getBoolean1 should be(true)
+  }
 }


### PR DESCRIPTION
@balagez This PR extends the `@safeConfig` macro to work on `class`es so that it can be used with Play 2.4 (in light of https://github.com/scalamacros/paradise/issues/49).
