### PR TITLE
Enable most warts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.kinja"
 version := "1.1.2-SNAPSHOT"
 
 scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.12.8")
+crossScalaVersions := Seq("2.12.8", "2.11.12")
 
 scalacOptions ++= Seq(
   "-deprecation",          // Show details of deprecation warnings.

--- a/build.sbt
+++ b/build.sbt
@@ -29,19 +29,7 @@ scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Preserve)
   .setPreference(SpaceBeforeColon, true)
 
-wartremoverErrors ++= Warts.allBut(
-  Wart.Any,
-  Wart.Equals,
-  Wart.NonUnitStatements,
-  Wart.Nothing,
-  Wart.OptionPartial,
-  Wart.Overloading,
-  Wart.PublicInference,
-  Wart.Throw,
-  Wart.ToString,
-  Wart.TraversableOps,
-  Wart.Var
-)
+wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading)
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.2",

--- a/src/main/scala/com/kinja/config/BootupErrors.scala
+++ b/src/main/scala/com/kinja/config/BootupErrors.scala
@@ -10,10 +10,10 @@ final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[ConfigE
   /** Sequentially apply another BootupErrors to this one, accumulating any errors therein. */
   def <*>[B, C](that : BootupErrors[B])(implicit ev : <:<[A, B => C]) : BootupErrors[C] = BootupErrors {
     (this.run, that.run) match {
-      case (Right(g), Right(k)) => Right(g(k))
-      case (Left(e), Right(k))  => Left(e)
-      case (Right(e), Left(k))  => Left(k)
-      case (Left(e), Left(k))   => Left(e ++ k)
+      case (Right(g), Right(k)) => Right[Seq[ConfigError], C](g(k))
+      case (Left(e), Right(k))  => Left[Seq[ConfigError], C](e)
+      case (Right(e), Left(k))  => Left[Seq[ConfigError], C](k)
+      case (Left(e), Left(k))   => Left[Seq[ConfigError], C](e ++ k)
     }
   }
 
@@ -41,8 +41,8 @@ final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[ConfigE
 }
 
 object BootupErrors {
-  def apply[A](a : A) : BootupErrors[A] = BootupErrors(Right(a))
-  def failed[A](err : ConfigError) : BootupErrors[A] = BootupErrors(Left(err :: Nil))
+  def apply[A](a : A) : BootupErrors[A] = BootupErrors(Right[Seq[ConfigError], A](a))
+  def failed[A](err : ConfigError) : BootupErrors[A] = BootupErrors(Left[Seq[ConfigError], A](err :: Nil))
 
   def sequence[A](as : List[BootupErrors[A]]) : BootupErrors[List[A]] =
     as.foldRight(BootupErrors(List.empty[A])) {

--- a/src/main/scala/com/kinja/config/LiftedTypesafeConfig.scala
+++ b/src/main/scala/com/kinja/config/LiftedTypesafeConfig.scala
@@ -70,6 +70,7 @@ final case class LiftedTypesafeConfig private[LiftedTypesafeConfig] (configAndNa
   def getObject(name : String) : BootupErrors[ConfigObject] = lift(name, underlying.getObject)
 
   /** Retrieves the value found at the given name as a ConfigObject. */
+  @SuppressWarnings(Array("org.wartremover.warts.Nothing"))
   def getObjectList(name : String) : BootupErrors[List[ConfigObject]] =
     lift(name, underlying.getObjectList).map(_.asScala.toList)
 
@@ -78,7 +79,7 @@ final case class LiftedTypesafeConfig private[LiftedTypesafeConfig] (configAndNa
 
   /** Retrieves the value found at the given name as a List of Strings. */
   def getStringList(name : String) : BootupErrors[List[String]] =
-    lift(name, underlying.getStringList).map(_.asScala.toList)
+    lift[java.util.List[String]](name, underlying.getStringList).map(_.asScala.toList)
 
   /**
    * As `getConfig` but this returns the underyling TypesafeConfig.

--- a/src/main/scala/com/kinja/config/safeConfig.scala
+++ b/src/main/scala/com/kinja/config/safeConfig.scala
@@ -104,9 +104,9 @@ object safeConfig {
               case ((idents, block), t @ ValDef(_, name, _, _)) =>
                 val args = idents - name
                 stack = args +: stack
-                try (
+                try {
                   args -> (super.transform(t) :: block)
-                  ) finally { stack = stack.tail }
+                } finally { stack = stack.tail }
               case ((idents, block), t) =>
                 idents -> (super.transform(t) :: block)
             }

--- a/src/main/scala/com/kinja/config/safeConfig.scala
+++ b/src/main/scala/com/kinja/config/safeConfig.scala
@@ -180,8 +180,8 @@ object safeConfig {
             case (name, valDef) =>
               val tpeOpt : Option[Tree] = valDef.tpt match {
                 case AppliedTypeTree(tpt, args) => args.headOption
-                case tpe =>
-                  tpe.tpe match {
+                case tree =>
+                  tree.tpe match {
                     case TypeRef(_, _, typ :: Nil) => Some(tq"$typ")
                     case _                         => None
                   }

--- a/src/test/scala/com/kinja/config/DependencyInjection.scala
+++ b/src/test/scala/com/kinja/config/DependencyInjection.scala
@@ -3,5 +3,5 @@ package com.kinja.config
 import com.typesafe.config._
 
 abstract class DependencyInjection {
-  lazy val injectedConfig = ConfigFactory.load()
+  lazy val injectedConfig : Config = ConfigFactory.load()
 }

--- a/src/test/scala/com/kinja/config/TestConfigs.scala
+++ b/src/test/scala/com/kinja/config/TestConfigs.scala
@@ -4,6 +4,7 @@ import com.typesafe.config._
 
 import scala.concurrent.duration.Duration
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.PublicInference"))
 @safeConfig(testConf)
 object TestConfig {
 
@@ -119,35 +120,41 @@ object EmptyConfig {
 
 final case class SomethingConfig(foo : Int, bar : String)
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 @safeConfig("injectedConfig")
 class DepInjTest1() extends DependencyInjection {
-  val getBoolean1 = getBoolean("bool")
+  val getBoolean1 : BootupErrors[Boolean] = getBoolean("bool")
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 @safeConfig("rawConfig")
 class DepInjTest2() extends DependencyInjection {
   private val rawConfig = injectedConfig
-  val getBoolean1 = getBoolean("bool")
+  val getBoolean1 : BootupErrors[Boolean] = getBoolean("bool")
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 @safeConfig("rawConfig")
 class DepInjTest3() extends DependencyInjection {
   private val rawConfig : com.typesafe.config.Config = injectedConfig
-  val getBoolean1 = getBoolean("bool")
+  val getBoolean1 : BootupErrors[Boolean] = getBoolean("bool")
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 @safeConfig(testConf)
 object ProtectedMemberTest extends ProtectedMember {
-  val getBoolean1 = getBoolean(someString)
+  val getBoolean1 : BootupErrors[Boolean] = getBoolean(someString)
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 @safeConfig(testConf)
 class ClassArgTest1(private val someString : String) {
-  val getBoolean1 = getBoolean(someString)
+  val getBoolean1 : BootupErrors[Boolean] = getBoolean(someString)
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 @safeConfig("rawConfig")
 class ClassArgTest2(private val rawConfig : Config) {
 
-  val secret = getString("string")
+  val secret : BootupErrors[String] = getString("string")
 }

--- a/src/test/scala/com/kinja/config/package.scala
+++ b/src/test/scala/com/kinja/config/package.scala
@@ -3,5 +3,5 @@ package com.kinja
 import com.typesafe.config._
 
 package object config {
-  val testConf = ConfigFactory.load()
+  val testConf : Config = ConfigFactory.load()
 }

--- a/src/test/scala/com/kinja/config/safeConfigTest.scala
+++ b/src/test/scala/com/kinja/config/safeConfigTest.scala
@@ -2,6 +2,12 @@ package com.kinja.config
 
 import org.scalatest._
 
+import scala.concurrent.duration.Duration
+
+@SuppressWarnings(Array(
+  "org.wartremover.warts.NonUnitStatements",
+  "org.wartremover.warts.Throw"
+))
 class safeConfigTest extends FlatSpec with Matchers {
   "safeConfig" should "handle getBoolean" in {
     TestConfig.getBoolean1 should be(true)
@@ -89,8 +95,8 @@ class safeConfigTest extends FlatSpec with Matchers {
     val errorMessage = try {
       @safeConfig(testConf)
       object MissingConf {
-        val foo = getString("does-not-exist")
-        val bar = getInt("also-does-not-exist")
+        val foo : BootupErrors[String] = getString("does-not-exist")
+        val bar : BootupErrors[Int] = getInt("also-does-not-exist")
       }
       MissingConf
       ""
@@ -104,8 +110,8 @@ class safeConfigTest extends FlatSpec with Matchers {
     val errorMessage = try {
       @safeConfig(testConf)
       object WrongTypeConf {
-        val foo = getInt("string")
-        val bar = getDuration("object-list")
+        val foo : BootupErrors[Int] = getInt("string")
+        val bar : BootupErrors[Duration] = getDuration("object-list")
       }
       WrongTypeConf
       ""


### PR DESCRIPTION
The safeConfig macro no longer generates code without explicit type ascriptions on public members.
Also enabled most warts and suppressed the warnings where fixing is not possible or not practical.