### PR TITLE
Scala 2.13 support, drop Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading)
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.4",
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
 libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -4,21 +4,31 @@ name := "safe-config"
 organization := "com.kinja"
 version := "1.1.2-SNAPSHOT"
 
-scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.12.8", "2.11.12")
+scalaVersion := "2.13.0"
+crossScalaVersions := Seq("2.13.0", "2.12.8")
 
 scalacOptions ++= Seq(
   "-deprecation",          // Show details of deprecation warnings.
   "-encoding", "UTF-8",    // Set correct encoding for Scaladoc.
   "-feature",              // Show details of feature warnings.
   "-unchecked",            // Show details of unchecked warnings.
-  "-Xfatal-warnings",      // All warnings should result in a compiliation failure.
-  "-Xfuture",              // Disables view bounds, adapted args, and unsound pattern matching in 2.11.
   "-Xlint",                // Ensure best practices are being followed.
-  "-Yno-adapted-args",     // Prevent implicit tupling of arguments.
   "-Ywarn-dead-code",      // Fail when dead code is present. Prevents accidentally unreachable code.
   "-Ywarn-value-discard"   // Prevent accidental discarding of results in unit functions.
 )
+
+scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+    Seq(
+      "-Ymacro-annotations"
+    )
+  case _ =>
+    Seq(
+      "-Xfatal-warnings",  // All warnings should result in a compiliation failure.
+      "-Yno-adapted-args", // No longer needed in Scala 2.13
+      "-Xfuture"           // Deprecated in Scala 2.13
+    )
+})
 
 scalariformAutoformat := true
 scalariformPreferences := scalariformPreferences.value
@@ -29,14 +39,20 @@ scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Preserve)
   .setPreference(SpaceBeforeColon, true)
 
-wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading)
+wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading, Wart.NonUnitStatements, Wart.Nothing)
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.2",
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
+
+libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+    Seq()
+  case _ =>
+    Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))
+})
 
 lazy val root = Project("safe-config", file("."))
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ scalariformPreferences := scalariformPreferences.value
 wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading)
 
 libraryDependencies ++= Seq(
-  "com.typesafe" % "config" % "1.3.2",
+  "com.typesafe" % "config" % "1.3.4",
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Preserve)
   .setPreference(SpaceBeforeColon, true)
 
-wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading, Wart.NonUnitStatements, Wart.Nothing)
+wartremoverErrors ++= Warts.allBut(Wart.Equals, Wart.Overloading)
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.2",

--- a/src/main/scala/com/kinja/config/BootupErrors.scala
+++ b/src/main/scala/com/kinja/config/BootupErrors.scala
@@ -5,7 +5,7 @@ package com.kinja.config
  * It is also a monad (but does not accumulate errors in that case).
  */
 final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[ConfigError], A]) extends AnyVal {
-  def map[B](f : A => B) : BootupErrors[B] = BootupErrors(this.run.right.map(f))
+  def map[B](f : A => B) : BootupErrors[B] = BootupErrors(this.run.map(f))
 
   /** Sequentially apply another BootupErrors to this one, accumulating any errors therein. */
   def <*>[B, C](that : BootupErrors[B])(implicit ev : <:<[A, B => C]) : BootupErrors[C] = BootupErrors {
@@ -20,7 +20,7 @@ final case class BootupErrors[A] private[BootupErrors] (run : Either[Seq[ConfigE
   def flatten[B](implicit ev : A <:< BootupErrors[B]) : BootupErrors[B] = this.flatMap(a => a)
 
   /** Bind on another BootupErrors. Unlike `<*>` this does not accumulate errors. */
-  def flatMap[B](f : A => BootupErrors[B]) : BootupErrors[B] = BootupErrors(this.run.right.flatMap(f(_).run))
+  def flatMap[B](f : A => BootupErrors[B]) : BootupErrors[B] = BootupErrors(this.run.flatMap(f(_).run))
 
   def fold[B](err : Seq[ConfigError] => B, succ : A => B) : B = run.fold(err, succ)
   def getOrElse(e : Seq[ConfigError] => A) : A = this.fold(e, a => a)

--- a/src/main/scala/com/kinja/config/LiftedTypesafeConfig.scala
+++ b/src/main/scala/com/kinja/config/LiftedTypesafeConfig.scala
@@ -4,7 +4,8 @@ import com.typesafe.config._
 
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters._ // TODO deprecated in Scala 2.13
+// import scala.jdk.CollectionConverters._ // TODO Scala 2.13 only
 import scala.concurrent.duration.Duration
 
 /**

--- a/src/main/scala/com/kinja/config/safeConfig.scala
+++ b/src/main/scala/com/kinja/config/safeConfig.scala
@@ -19,6 +19,8 @@ object safeConfig {
 
   @SuppressWarnings(Array(
     "org.wartremover.warts.Any",
+    "org.wartremover.warts.NonUnitStatements",
+    "org.wartremover.warts.Nothing",
     "org.wartremover.warts.ToString",
     "org.wartremover.warts.Var"
   ))

--- a/src/main/scala/com/kinja/config/safeConfig.scala
+++ b/src/main/scala/com/kinja/config/safeConfig.scala
@@ -61,12 +61,6 @@ object safeConfig {
         case t : TermSymbol => q"""var ${t.name.toTermName} : ${t.typeSignature} = (throw new java.lang.Exception("")) : ${t.typeSignature}"""
       }
 
-      @SuppressWarnings(Array(
-        "org.wartremover.warts.NonUnitStatements",
-        "org.wartremover.warts.Nothing"
-      ))
-      def isBootupErrors(typ : Type) : Boolean = typ <:< typeOf[BootupErrors[_]]
-
       // Previous definitions. Used for type checking.
       // TODO: Typecheck the whole block at once to allow for forward references.
       //       This will require some serious reworking of the implementation.
@@ -82,7 +76,7 @@ object safeConfig {
           thusFar = thusFar :+ ValDef(mods, name, tq"$typ", rhs)
 
           // Ignore pure values.
-          if (isBootupErrors(typ))
+          if (typ <:< typeOf[BootupErrors[_]])
             List(name -> ValDef(Modifiers(PRIVATE | flags, pw, ann), freshTerm(), tq"$typ", rhs))
           else
             List.empty[(TermName, ValDef)]

--- a/src/test/scala/com/kinja/config/safeConfigTest.scala
+++ b/src/test/scala/com/kinja/config/safeConfigTest.scala
@@ -4,7 +4,10 @@ import org.scalatest._
 
 import scala.concurrent.duration.Duration
 
-@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+@SuppressWarnings(Array(
+  "org.wartremover.warts.NonUnitStatements",
+  "org.wartremover.warts.Throw"
+))
 class safeConfigTest extends FlatSpec with Matchers {
   "safeConfig" should "handle getBoolean" in {
     TestConfig.getBoolean1 should be(true)

--- a/src/test/scala/com/kinja/config/safeConfigTest.scala
+++ b/src/test/scala/com/kinja/config/safeConfigTest.scala
@@ -4,10 +4,7 @@ import org.scalatest._
 
 import scala.concurrent.duration.Duration
 
-@SuppressWarnings(Array(
-  "org.wartremover.warts.NonUnitStatements",
-  "org.wartremover.warts.Throw"
-))
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 class safeConfigTest extends FlatSpec with Matchers {
   "safeConfig" should "handle getBoolean" in {
     TestConfig.getBoolean1 should be(true)
@@ -50,13 +47,13 @@ class safeConfigTest extends FlatSpec with Matchers {
   }
 
   it should "handle getLong" in {
-    TestConfig.getLong1 should be(2147483648l)
-    TestConfig.getLong2 should be(2147483648l)
+    TestConfig.getLong1 should be(2147483648L)
+    TestConfig.getLong2 should be(2147483648L)
   }
 
   it should "handle getLongList" in {
-    TestConfig.getLongList1 should be(List(2147483648l, 2147483649l, 2147483650l))
-    TestConfig.getLongList2 should be(List(2147483648l, 2147483649l, 2147483650l))
+    TestConfig.getLongList1 should be(List(2147483648L, 2147483649L, 2147483650L))
+    TestConfig.getLongList2 should be(List(2147483648L, 2147483649L, 2147483650L))
   }
 
   it should "handle getObject" in {


### PR DESCRIPTION
Added support for Scala 2.13.

Removed support for Scala 2.11 (`Either` is not fully source compatible across 2.11 and 2.13, we could probably make it work if needed, but I didn't find it important to keep supporting 2.11).